### PR TITLE
Migrating from master/slave lingo

### DIFF
--- a/app/eventpool.py
+++ b/app/eventpool.py
@@ -92,7 +92,7 @@ class EventPool():
 
     def __read_temperature(self, sensor) -> tuple:
         # read the temperature from the GPIO
-        device_file = sensor[2] + '/w1_slave'
+        device_file = sensor[2] + '/w1_subordinate'
         reg_confirm = re.compile('YES')
         reg_temp = re.compile('t=(\d+)')
         temp_c = None

--- a/app/routes.py
+++ b/app/routes.py
@@ -165,7 +165,7 @@ def read_temp(sensor):
     conn = db(current_app.config['APP_DATABASE'])
     sensor = db.run_query_result_many(c_queries.GET_SENSOR, (sensor, ))
 
-    device_file = sensor[2] + '/w1_slave'
+    device_file = sensor[2] + '/w1_subordinate'
     reg_confirm = re.compile('YES')
     reg_temp = re.compile('t=(\d+)')
     temp_c = None


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.